### PR TITLE
supposedly fixes #7

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
       version="0.1.0">
 
     <engines>
-        <engine name="cordova" version="3.0.0" />
+        <engine name="cordova" version=">=3.0" />
     </engines>
     <name>WebSocket</name>
 


### PR DESCRIPTION
Okay, so this is what I think works; see this log:

```
localhost:~ makc$ phonegap create test
[phonegap] created project at /Users/makc/test
localhost:~ makc$ cd test
localhost:test makc$ phonegap build android
[phonegap] detecting Android SDK environment...
[phonegap] using the local environment
[phonegap] adding the Android platform...
[phonegap] compiling Android...
[phonegap] successfully compiled Android app
localhost:test makc$ cordova plugin add https://github.com/makc/phonegap-websocket
[Error: Plugin doesn't support this project's Cordova version. Project version: 3.0.0-rc1, failed version requirement: 3.0.0]
localhost:test makc$ phonegap build android
[phonegap] detecting Android SDK environment...
[phonegap] using the local environment
[phonegap] compiling Android...
[phonegap] successfully compiled Android app
localhost:test makc$ cd platforms/android/bin/classes/org
-bash: cd: platforms/android/bin/classes/org: No such file or directory
localhost:test makc$ phonegap create ../test1
[phonegap] created project at /Users/makc/test1
localhost:test makc$ cd ../test1
localhost:test1 makc$ phonegap build android
[phonegap] detecting Android SDK environment...
[phonegap] using the local environment
[phonegap] adding the Android platform...
[phonegap] compiling Android...
[phonegap] successfully compiled Android app
localhost:test1 makc$ cordova plugin add https://github.com/code-orchestra/phonegap-websocket
localhost:test1 makc$ phonegap build android
[phonegap] detecting Android SDK environment...
[phonegap] using the local environment
[phonegap] compiling Android...
[phonegap] successfully compiled Android app
localhost:test1 makc$ cd platforms/android/bin/classes/org
localhost:org makc$ pwd
/Users/makc/test1/platforms/android/bin/classes/org
```
