### PR TITLE
Change to constructor and binary support ported from 2.x.x branch

### DIFF
--- a/src/com/ququplay/websocket/CordovaClient.java
+++ b/src/com/ququplay/websocket/CordovaClient.java
@@ -1,6 +1,7 @@
 package com.ququplay.websocket;
 
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,6 +20,7 @@ import org.java_websocket.framing.FrameBuilder;
 import org.java_websocket.framing.Framedata;
 import org.java_websocket.framing.FramedataImpl1;
 import org.java_websocket.handshake.ServerHandshake;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -73,14 +75,28 @@ public class CordovaClient extends WebSocketClient {
   }
   
   @Override
+  public void onMessage(ByteBuffer bytes) {
+  
+	  JSONArray jsonArr = Utils.byteArrayToJSONArray(bytes.array());
+      sendResult(jsonArr, "messageBinary", PluginResult.Status.OK);
+  }
+
+  @Override
   public void onFragment(Framedata frame) {
     try {
       this.frameBuilder.append(frame);
 
 	    // last frame?
 	    if (frame.isFin()) {
-	      byte[] bytes = this.frameBuilder.getPayloadData().array();
-	      this.onMessage(new String( bytes, Charset.forName("UTF-8") ));
+	        ByteBuffer bytes = this.frameBuilder.getPayloadData();
+	    
+	        if (this.frameBuilder.getOpcode() == Framedata.Opcode.BINARY) {
+	    	
+	          this.onMessage(bytes);
+	    
+	        } else {
+	          this.onMessage(new String( bytes.array(), Charset.forName("UTF-8") ));
+	      }
 	      this.frameBuilder.getPayloadData().clear();
 	    }
 	    
@@ -97,14 +113,14 @@ public class CordovaClient extends WebSocketClient {
     sendResult(ex.getMessage(), "error", PluginResult.Status.ERROR);
   }
 
-  private void sendResult(String message, String type, Status status) {
+  private void sendResult(Object message, String type, Status status) {
     JSONObject event = createEvent(message, type);
     PluginResult pluginResult = new PluginResult(status, event);
     pluginResult.setKeepCallback(true);
     this.callbackContext.sendPluginResult(pluginResult);
   }
 
-  private JSONObject createEvent(String data, String type) {
+  private JSONObject createEvent(Object data, String type) {
     JSONObject event;
 
     try {

--- a/src/com/ququplay/websocket/Utils.java
+++ b/src/com/ququplay/websocket/Utils.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -19,6 +20,27 @@ public class Utils {
       result.put(key, data.getString(key));
     }
 
+    return result;
+  }
+   
+  public static byte[] jsonArrayToByteArray(JSONArray data)
+      throws JSONException {
+
+    byte result[] = new byte[data.length()];
+    for (int i = 0; i < data.length(); i++) {
+
+      result[i] = (byte) data.getInt(i);
+    }
+    return result;
+  }
+
+  public static JSONArray byteArrayToJSONArray(byte data[]) {
+
+    JSONArray result = new JSONArray();
+    for (int i = 0; i < data.length; i++) {
+
+      result.put((int) data[i]);
+    }
     return result;
   }
 }

--- a/src/com/ququplay/websocket/WebSocket.java
+++ b/src/com/ququplay/websocket/WebSocket.java
@@ -57,7 +57,7 @@ public class WebSocket extends CordovaPlugin {
     }
     else if (ACTION_SEND.equals(action)) {
       final String socketId = args.getString(0);
-      final String data = args.getString(1);
+      final Object data = args.get(1);
       cordova.getThreadPool().execute(new Runnable() {
         public void run() {
           plugin.send(socketId, data);
@@ -157,13 +157,28 @@ public class WebSocket extends CordovaPlugin {
     catch (JSONException e) {}
   }
 
-  private void send(String socketId, String data) {
-    final CordovaClient client = clients.get(socketId);
-    if (data != null && data.length() > 0 &&
-      client != null &&
-      client.getConnection() != null &&
-      client.getConnection().isOpen()) {
-      client.send(data);
-    }
-  }
+	private void send(String socketId, Object data) {
+		try {
+			final CordovaClient client = clients.get(socketId);
+			if (data != null && client != null
+					&& client.getConnection() != null
+					&& client.getConnection().isOpen()) {
+
+				if (data instanceof JSONArray
+						&& ((JSONArray) data).length() > 0) {
+
+					byte decoded[] = Utils
+							.jsonArrayToByteArray((JSONArray) data);
+					client.send(decoded);
+
+				} else if (data instanceof String
+						&& ((String) data).length() > 0) {
+
+					client.send((String) data);
+				}
+			}
+		} catch (JSONException e) {
+			e.printStackTrace();
+		}
+	}
 }

--- a/www/phonegap-websocket.js
+++ b/www/phonegap-websocket.js
@@ -3,10 +3,35 @@ var exec = require('cordova/exec');
 var _websocket_id = 0;
 
 // Websocket constructor
-var WebSocket = function (url, options) {
+var WebSocket = function(url, opt1, opt2) {
   var socket = this;
   
-  options || (options = {});
+  var protocols = null;
+  var options = opt2 ? opt2 : {};
+  if (typeof opt1 === "string") {
+  
+	  protocols = opt1.trim();
+  
+  } else if (Array.isArray(opt1)) {
+  
+    for ( var i = 0; i < opt1.length; i++) {
+  
+      if (i > 0) {
+  
+        protocols += ", ";
+      }
+      protocols += opt1[i].trim();
+    }
+  
+  } else if (opt1 !== null && typeof opt1 === "object") {
+
+    options = opt1;
+  }
+  if (protocols !== null) {
+
+    options.headers || (options.headers = {});
+    options.headers["Sec-WebSocket-Protocol"] = protocols;
+  }
 
   this.events = [];
   this.options = options;
@@ -30,7 +55,19 @@ WebSocket.prototype = {
         this.readyState == WebSocket.CLOSING) {
       return;
     }
-
+    if (data instanceof ArrayBuffer) {
+        
+      data = this._arrayBufferToArray(data);
+    
+    } else if (data instanceof Blob) {
+    
+      var reader = new FileReader();
+      reader.onloadend = function() {
+        this.send(reader.result);
+      }.bind(this);
+      reader.readAsArrayBuffer(data);
+      return;
+    }
     exec(function () {}, function () {}, "WebSocket", "send", [ this.socketId, data ]);
   },
 
@@ -78,9 +115,19 @@ WebSocket.prototype = {
 
   _handleEvent: function (event) {
     this.readyState = event.readyState;
-    event = (event.type == "message") ?
-      event = this._createMessageEvent("message", event.data) :
+    if (event.type == "message") {
+    
+      event = this._createMessageEvent("message", event.data);
+    
+    } else if (event.type == "messageBinary") {
+    
+      var result = this._arrayToBinaryType(event.data, this.binaryType);
+      event = this._createBinaryMessageEvent("message", result);
+    
+    } else {
+    
       event = this._createSimpleEvent(event.type);
+    }
     this.dispatchEvent(event);
     if (event.readyState == WebSocket.CLOSING || event.readyState == WebSocket.CLOSED) {
       // cleanup socket from internal map
@@ -102,6 +149,50 @@ WebSocket.prototype = {
     event.initMessageEvent("message", false, false, data, null, null, window, null);
 
     return event;
+  },
+  
+  _createBinaryMessageEvent : function(type, data) {
+
+    // This does not match the WebSocket spec. The Event is suppose to be a
+    // MessageEvent. But in Android WebView, MessageEvent.initMessageEvent() 
+    // makes a mess of ArrayBuffers.  This should work with most clients, as
+    // long as they don't do something odd with the event.  The type is 
+    // correctly set to "message", so client event routing logic should work.
+    var event = document.createEvent("Event");
+
+    event.initEvent("message", false, false);
+    event.data = data;
+    return event;
+  },
+  
+  _arrayBufferToArray : function(arrayBuffer) {
+
+    var output = [];
+    var utf8arr = new Uint8Array(arrayBuffer);
+    for ( var i = 0; i < utf8arr.length; i++) {
+
+      output.push(utf8arr[i]);
+    }
+    return output;
+  },
+  
+  _arrayToBinaryType : function(array, binaryType) {
+    
+    var result = null;
+    var typedArr = new Uint8Array(array.length);
+    typedArr.set(array);
+    
+    if (binaryType === "arraybuffer") {
+
+      result = typedArr.buffer;
+
+    } else if (binaryType === "blob") {
+      
+      var builder = new WebKitBlobBuilder();
+      builder.append(typedArr.buffer);
+      result = builder.getBlob("application/octet-stream");
+    }
+    return result;
   }
 };
 


### PR DESCRIPTION
Changed WebSocket constructor to allow passing subprotocol as second argument and implemented binary send/receive via ArrayBuffer and Blob
