### PR TITLE
Use native WebSockets on KitKat

### DIFF
--- a/www/phonegap-websocket.js
+++ b/www/phonegap-websocket.js
@@ -1,7 +1,14 @@
+var usingCordovaWebSocket = false;
+
+window.WebSocket || (function() {
+	
+usingCordovaWebSocket = true;
+
 var websocketId = 0;
 
 // Websocket constructor
-var WebSocket = function(url, protocols, options) {
+window.WebSocket = function(url, protocols, options) {
+		
   var socket = this;
   options || (options = {});
   options.headers || (options.headers = {});
@@ -180,4 +187,6 @@ function arrayToBinaryType(array, binaryType) {
 
 Array.isArray = Array.isArray || function (args) {
   return Object.prototype.toString.call(args) === "[object Array]";
-}
+};
+
+}());


### PR DESCRIPTION
Added check to see whether WebSockets are available.  Also added global boolean usingCordovaWebSocket.  Unfortunately, native WebSockets on KitKat do not tolerate the options object in the constructor.  Client code that uses the options object will have to do something like: 

```
if (usingCordovaWebSocket) {

    socket = new WebSocket("ws://10.0.2.2:9003", "", { draft : "draft17" });

} else {

    socket = new WebSocket("ws://10.0.2.2:9003");
}
```
