### PR TITLE
FIX dispatchEvent: call eventHandler in context of the WebSocket

### DIFF
--- a/www/phonegap-websocket.js
+++ b/www/phonegap-websocket.js
@@ -101,11 +101,13 @@ hasWebSocket() || (function() {
       var events = this.events[event.type] || [];
 
       for (var i = 0, l = events.length; i < l; i++) {
-        events[i](event);
+        //FIX (russaa): call event handler in context of the WebSocket instance
+        events[i].call(this, event);
       }
 
       handler = this["on" + event.type];
-      if (handler) handler(event);
+      //FIX (russaa): call event handler in context of the WebSocket instance
+      if (handler) handler.call(this, event);
     },
 
     _handleEvent: function (event) {
@@ -208,15 +210,15 @@ hasWebSocket() || (function() {
 
   Array.isArray = Array.isArray || function (args) {
     return Object.prototype.toString.call(args) === "[object Array]";
-  }
+  };
   
   window.ArrayBuffer = window.ArrayBuffer || function () {
     throw "ArrayBuffer not supported on this platform";
-  }
+  };
   
   window.Blob = window.Blob || function () {
     throw "Blob not supported on this platform";
-  }
+  };
 
 }());
 


### PR DESCRIPTION
small fix in function dispatchEvent():
call the event handlers in context of the WebSocket instance (instead of global/window context)
