### PR TITLE
FIX _handelEvent: set readyState value to CLOSED (3) for 'close' event

### DIFF
--- a/www/phonegap-websocket.js
+++ b/www/phonegap-websocket.js
@@ -108,6 +108,24 @@ hasWebSocket() || (function() {
     },
 
     _handleEvent: function (event) {
+      //FIX need to set readyState to 3 (CLOSED) manually here, in case
+      // the close-event was triggered!
+      //
+      // Explanation:
+      //
+      // The Java impl. changes readyState to 3 (CLOSED) only after the event-handler
+      // for the 'close' event returns (i.e. after notifying / triggering this function),
+      // BUT readyState should be CLOSED already here in the JavaScript impl., so that 
+      // on entering the WebSocket's onclose handler(s), the correct readyState 3 (CLOSED)
+      // is set / available!
+      //
+      // see e.g. 
+      // https://chromium.googlesource.com/external/w3c/web-platform-tests/+/Moz_Bug_819051_test/websockets/Secure-Close-readyState-Closed.htm
+      //
+      if(event.type == 'close'){
+        this.readyState = WebSocket.CLOSED;	
+      } else
+      //FIX: end.
       this.readyState = event.readyState;
 
       if (event.type == "message") {


### PR DESCRIPTION
Fix for readState value when internal _handleEvent is triggered with 'close' event:
need to set readyState to 3 (CLOSED) manually.

Explanation:
The Java impl. changes the readyState to 3 (CLOSED) only after the event-handler for the 'close' event returns (i.e. after this JavaScript function returns), BUT readyState should be set to 3 (CLOSED) already in _handleEvent since the registered event handlers are invoked from here; in case of a 'close' event the readyState should be 3 (CLOSED) so that on entering the WebSocket's onclose handler(s), the correct readyState is set / available.

NOTE: I did only check / test the phonegap-2.x.x branch for this, but I suspect this needs also be done for the master branch.

See WebSocket spec. for closing procedure (note that readyState is set to CLOSED before close-event is fired)
http://www.w3.org/TR/websockets/#closeWebSocket

For  an example / test case definition with regard to readyState value within an invoked 'close'-handler function see e.g.
https://chromium.googlesource.com/external/w3c/web-platform-tests/+/Moz_Bug_819051_test/websockets/Secure-Close-readyState-Closed.htm
