### PR TITLE
Pass back code and reason from onClose

### DIFF
--- a/src/com/ququplay/websocket/CordovaClient.java
+++ b/src/com/ququplay/websocket/CordovaClient.java
@@ -104,7 +104,18 @@ public class CordovaClient extends WebSocketClient {
 
   @Override
   public void onClose(int code, String reason, boolean remote) {
-    sendResult("", "close", PluginResult.Status.OK);
+	JSONObject event = null;
+	//Add close specific information
+	try {
+      event = createEvent("", "close");
+	  event.put("code", Integer.toString(code));
+      event.put("reason", reason);
+    }
+    catch (JSONException e) {
+      e.printStackTrace();
+    }
+	
+	sendResult(event, PluginResult.Status.OK);
   }
 
   @Override
@@ -114,6 +125,10 @@ public class CordovaClient extends WebSocketClient {
 
   private void sendResult(Object message, String type, Status status) {
     JSONObject event = createEvent(message, type);
+    sendResult(event, status);
+  }
+
+  private void sendResult(JSONObject event, Status status) {
     PluginResult pluginResult = new PluginResult(status, event);
     pluginResult.setKeepCallback(true);
     this.callbackContext.sendPluginResult(pluginResult);

--- a/www/phonegap-websocket.js
+++ b/www/phonegap-websocket.js
@@ -113,15 +113,24 @@ hasWebSocket() || (function() {
     _handleEvent: function (event) {
       this.readyState = event.readyState;
 
-      if (event.type == "message") {
+      switch (event.type) {
+      case "message":
         event = createMessageEvent("message", event.data);
-      } 
-      else if (event.type == "messageBinary") {
+        break;
+      case "messageBinary":
         var result = arrayToBinaryType(event.data, this.binaryType);
         event = createBinaryMessageEvent("message", result);
-      } 
-      else {
+        break;
+      case "close":
+        var reason = event.reason;
+        var code = event.code;
+        event = this._createSimpleEvent(event.type);
+        event.reason = reason;
+        event.code = code;
+        break;
+      default:
         event = createSimpleEvent(event.type);
+        break;
       }
       
       this.dispatchEvent(event);


### PR DESCRIPTION
It looks like previously this websocket plug-in would not return the error and reason when an onClose event was generated.  For consistency between iOS and other platforms this should be included to the javascript layer.  It helps determine the reason the close occurred and is useful for troubleshooting.
